### PR TITLE
Make `json` output optional in the API

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -88,7 +88,8 @@ pub(crate) fn run_weighted_code_coverage(args: Args) {
         .thresholds(args.thresholds)
         .n_threads(args.threads)
         .mode(args.mode)
-        .sort_by(args.sort);
+        .sort_by(args.sort)
+        .json_path(&args.json);
 
     // If present, set the path of the html output directory.
     if let Some(html_path) = &args.html {
@@ -102,7 +103,5 @@ pub(crate) fn run_weighted_code_coverage(args: Args) {
     };
 
     // Run WccRunner.
-    wcc_runner
-        .run(&args.project_path, grcov_file, &args.json)
-        .unwrap();
+    wcc_runner.run(&args.project_path, grcov_file).unwrap();
 }

--- a/tests/output_test.rs
+++ b/tests/output_test.rs
@@ -50,12 +50,9 @@ fn compare(grcov_file: GrcovFile<&Path>, mode: Mode, snapshot_name: &str) {
 
     let output = WccRunner::new()
         .mode(mode)
+        .json_path(&output_dir.join(JSON_OUTPUT))
         .html_path(&output_dir)
-        .run(
-            Path::new(PROJECT_PATH),
-            grcov_file,
-            &output_dir.join(JSON_OUTPUT),
-        )
+        .run(Path::new(PROJECT_PATH), grcov_file)
         .unwrap();
 
     insta::with_settings!({


### PR DESCRIPTION
This pr makes the production of a `json` output optional, since those who use the library may not want to produce an output file, but only need the returned `struct WccOutput` that contains the metrics.